### PR TITLE
Performance optimizations and fixes

### DIFF
--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -152,19 +152,9 @@ extension String {
      - returns: Hamming distance
      */
     public func distanceHamming(between target: String) -> Int {
-        let selfCount = self.count
-        let targetCount = target.count
+        assert(self.count == target.count)
 
-        assert(selfCount == targetCount)
-
-        var dist = 0
-        for (i, selfCharacter) in self.enumerated() {
-            if selfCharacter != target[i] {
-                dist += 1
-            }
-        }
-
-        return dist
+        return zip(self, target).filter { $0 != $1 }.count
     }
 
     func MostFreqKHashing(str: String, K: Int) -> [Character: Int] {

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -43,15 +43,15 @@ extension String {
             v0[i] = i
         }
 
-        for i in 0..<selfCount {
+        for (i, selfCharacter) in self.enumerated() {
             // Calculate v1 (current row distances) from previous row v0
 
             // Edit distance is delete (i + 1) chars from self to match empty t.
             v1[0] = i + 1
 
             // Use formula to fill rest of the row.
-            for j in 0..<targetCount {
-                let cost = self[i] == target[j] ? 0 : 1
+            for (j, targetCharacter) in self.enumerated() {
+                let cost = selfCharacter == targetCharacter ? 0 : 1
                 v1[j + 1] = Swift.min(
                     v1[j] + 1,
                     v0[j + 1] + 1,
@@ -158,8 +158,8 @@ extension String {
         assert(selfCount == targetCount)
 
         var dist = 0
-        for i in 0..<selfCount {
-            if self[i] != target[i] {
+        for (i, selfCharacter) in self.enumerated() {
+            if selfCharacter != target[i] {
                 dist += 1
             }
         }

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -20,34 +20,37 @@ extension String {
      - returns: Levenshtein distance
      */
     public func distanceLevenshtein(between target: String) -> Int {
+        let selfCount = self.count
+        let targetCount = target.count
+
         if self == target {
             return 0
         }
-        if self.count == 0 {
-            return target.count
+        if selfCount == 0 {
+            return targetCount
         }
-        if target.count == 0 {
-            return self.count
+        if targetCount == 0 {
+            return selfCount
         }
 
         // The previous row of distances
-        var v0 = [Int](repeating: 0, count: target.count + 1)
+        var v0 = [Int](repeating: 0, count: targetCount + 1)
         // Current row of distances.
-        var v1 = [Int](repeating: 0, count: target.count + 1)
+        var v1 = [Int](repeating: 0, count: targetCount + 1)
         // Initialize v0.
         // Edit distance for empty self.
         for i in 0..<v0.count {
             v0[i] = i
         }
 
-        for i in 0..<self.count {
+        for i in 0..<selfCount {
             // Calculate v1 (current row distances) from previous row v0
 
             // Edit distance is delete (i + 1) chars from self to match empty t.
             v1[0] = i + 1
 
             // Use formula to fill rest of the row.
-            for j in 0..<target.count {
+            for j in 0..<targetCount {
                 let cost = self[i] == target[j] ? 0 : 1
                 v1[j + 1] = Swift.min(
                     v1[j] + 1,
@@ -62,7 +65,7 @@ extension String {
             }
         }
 
-        return v1[target.count]
+        return v1[targetCount]
     }
 
 
@@ -75,35 +78,38 @@ extension String {
      - returns: Damerau-Levenshtein distance
      */
     public func distanceDamerauLevenshtein(between target: String) -> Int {
+        let selfCount = self.count
+        let targetCount = target.count
+
         if self == target {
             return 0
         }
-        if self.count == 0 {
-            return target.count
+        if selfCount == 0 {
+            return targetCount
         }
-        if target.count == 0 {
-            return self.count
+        if targetCount == 0 {
+            return selfCount
         }
 
         var da: [Character: Int] = [:]
 
-        var d = Array(repeating: Array(repeating: 0, count: target.count + 2), count: self.count + 2)
+        var d = Array(repeating: Array(repeating: 0, count: targetCount + 2), count: selfCount + 2)
 
-        let maxdist = self.count + target.count
+        let maxdist = selfCount + targetCount
         d[0][0] = maxdist
-        for i in 1...self.count + 1 {
+        for i in 1...selfCount + 1 {
             d[i][0] = maxdist
             d[i][1] = i - 1
         }
-        for j in 1...target.count + 1 {
+        for j in 1...targetCount + 1 {
             d[0][j] = maxdist
             d[1][j] = j - 1
         }
 
-        for i in 2...self.count + 1 {
+        for i in 2...selfCount + 1 {
             var db = 1
 
-            for j in 2...target.count + 1 {
+            for j in 2...targetCount + 1 {
                 let k = da[target[j - 2]!] ?? 1
                 let l = db
 
@@ -131,7 +137,7 @@ extension String {
             da[self[i - 2]!] = i
         }
 
-        return d[self.count + 1][target.count + 1]
+        return d[selfCount + 1][targetCount + 1]
     }
 
 
@@ -146,10 +152,13 @@ extension String {
      - returns: Hamming distance
      */
     public func distanceHamming(between target: String) -> Int {
-        assert(self.count == target.count)
+        let selfCount = self.count
+        let targetCount = target.count
+
+        assert(selfCount == targetCount)
 
         var dist = 0
-        for i in 0..<self.count {
+        for i in 0..<selfCount {
             if self[i] != target[i] {
                 dist += 1
             }

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -242,14 +242,16 @@ extension String {
 
         // Count matching characters and transpositions.
         for (i, stringOneChar) in stringOne.enumerated() {
-            for j in max(0, i - matchingDistance)..<min(stringTwoCount, i + matchingDistance) {
-                if stringOneChar == stringTwo[j] {
-                    matchingCharactersCount += 1
-                    if previousPosition != -1 && j < previousPosition {
-                        transpositionsCount += 1
+            for (j, stringTwoChar) in stringTwo.enumerated() {
+                if max(0, i - matchingDistance)..<min(stringTwoCount, i + matchingDistance) ~= j {
+                    if stringOneChar == stringTwoChar {
+                        matchingCharactersCount += 1
+                        if previousPosition != -1 && j < previousPosition {
+                            transpositionsCount += 1
+                        }
+                        previousPosition = j
+                        break
                     }
-                    previousPosition = j
-                    break
                 }
             }
         }

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -158,13 +158,22 @@ extension String {
     }
 
     func MostFreqKHashing(str: String, K: Int) -> [Character: Int] {
+        // If `str` is shorter than `K` characters, use `str.count`
+        let clampedK = min(K, str.count)
         var freq: [Character: Int] = [:]
         for char in str {
             freq[char] = (freq[char] ?? 0) + 1
         }
 
         var KFreq: [Character: Int] = [:]
-        for (char, count) in  freq.sorted(by: {$0.value > $1.value})[0..<K]{
+        let sortedFreqs = freq.sorted { (charFreq1, charFreq2) -> Bool in
+            // If frequencies are equal, sort against character index in `str`
+            if charFreq1.value == charFreq2.value {
+                return str.firstIndex(of: charFreq1.key)! < str.firstIndex(of: charFreq2.key)!
+            }
+            return charFreq1.value > charFreq2.value
+        }
+        for (char, count) in sortedFreqs[0..<clampedK]{
             KFreq[char] = count
         }
 
@@ -174,8 +183,8 @@ extension String {
     func MostFreqKSimilarity(freq1: [Character: Int], freq2: [Character: Int]) -> Int {
         var similarity = 0
         for (char, count1) in freq1 {
-            if let count2 = freq2[char] {
-                similarity += count1 + count2
+            if freq2[char] != nil {
+                similarity += count1
             }
         }
         return similarity
@@ -184,7 +193,7 @@ extension String {
     /**
      Get most frequent K distance.
 
-     Reference <https://en.wikipedia.org/wiki/Most_frequent_k_characters>.
+     Reference <https://web.archive.org/web/20191117082524/https://en.wikipedia.org/wiki/Most_frequent_k_characters>.
 
      - parameters:
         - target: target string

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -50,7 +50,7 @@ extension String {
             v1[0] = i + 1
 
             // Use formula to fill rest of the row.
-            for (j, targetCharacter) in self.enumerated() {
+            for (j, targetCharacter) in target.enumerated() {
                 let cost = selfCharacter == targetCharacter ? 0 : 1
                 v1[j + 1] = Swift.min(
                     v1[j] + 1,

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension String {
     /**
      Get distance between target. (alias of `distanceJaroWinkler`.)
@@ -260,15 +262,8 @@ extension String {
         }
         t /= 2.0
 
-        // Count common prefix.
-        var l: Double = 0
-        for i in 0..<4 {
-            if self[i] == target[i] {
-                l += 1
-            } else {
-                break
-            }
-        }
+        // Count common prefix (up to a maximum of 4 characters)
+        let l = min(max(Double(self.commonPrefix(with: target).count), 0), 4)
 
         let dj = (m / Double(self.count) + m / Double(target.count) + (m - t) / m) / 3
 

--- a/Sources/StringMetric.swift
+++ b/Sources/StringMetric.swift
@@ -241,9 +241,9 @@ extension String {
         var previousPosition = -1
 
         // Count matching characters and transpositions.
-        for i in 0..<stringOneCount {
+        for (i, stringOneChar) in stringOne.enumerated() {
             for j in max(0, i - matchingDistance)..<min(stringTwoCount, i + matchingDistance) {
-                if stringOne[i] == stringTwo[j] {
+                if stringOneChar == stringTwo[j] {
                     matchingCharactersCount += 1
                     if previousPosition != -1 && j < previousPosition {
                         transpositionsCount += 1

--- a/Tests/StringMetricTests/StringExtTests.swift
+++ b/Tests/StringMetricTests/StringExtTests.swift
@@ -20,7 +20,7 @@ class StringExtTests: XCTestCase {
         XCTAssertEqual(s[-s.count-1], nil)
     }
 
-    func testStringSubscriptOfIntRagne() {
+    func testStringSubscriptOfIntRange() {
         let s = "YO"
 
         XCTAssertEqual(s[0..<2], "YO")
@@ -33,6 +33,6 @@ class StringExtTests: XCTestCase {
     static let allTests = [
         ("testStringCount", testStringCount),
         ("testStringSubscriptOfInt", testStringSubscriptOfInt),
-        ("testStringSubscriptOfRange", testStringSubscriptOfIntRagne),
+        ("testStringSubscriptOfRange", testStringSubscriptOfIntRange),
     ]
 }

--- a/Tests/StringMetricTests/StringMetricTests.swift
+++ b/Tests/StringMetricTests/StringMetricTests.swift
@@ -34,7 +34,7 @@ class StringMetricTests: XCTestCase {
         XCTAssertEqual("research".distanceMostFreqK(between: "seeking", K: 2), 6)
     }
 
-    func testDistanceJoraWinkler() {
+    func testDistanceJaroWinkler() {
         XCTAssertEqual("".distanceJaroWinkler(between: ""), 1.0)
         XCTAssertEqual("".distanceJaroWinkler(between: "Yo"), 0.0)
         XCTAssertEqual("search".distanceJaroWinkler(between: "find"), 0.0)
@@ -51,6 +51,6 @@ class StringMetricTests: XCTestCase {
         ("testDistanceDamerauLevenshtein", testDistanceDamerauLevenshtein),
         ("testDistanceHamming", testDistanceHamming),
         ("testDistanceMostFreqK", testDistanceMostFreqK),
-        ("testDistanceJoraWinkler", testDistanceJoraWinkler),
+        ("testDistanceJaroWinkler", testDistanceJaroWinkler),
     ]
 }

--- a/Tests/StringMetricTests/StringMetricTests.swift
+++ b/Tests/StringMetricTests/StringMetricTests.swift
@@ -46,6 +46,14 @@ class StringMetricTests: XCTestCase {
         XCTAssertEqual("君子和而不同".distanceJaroWinkler(between: "小人同而不和"), 0.555, accuracy: 0.001)
     }
 
+    func testDistanceMostFrequentK() {
+        XCTAssertEqual("night".distanceMostFreqK(between: "nacht", K: 2), 9)
+        XCTAssertEqual("my".distanceMostFreqK(between: "a", K: 2), 10)
+        XCTAssertEqual("research".distanceMostFreqK(between: "resarch", K: 2), 6)
+        XCTAssertEqual("aaaaabbbb".distanceMostFreqK(between: "ababababa", K: 2), 1)
+        XCTAssertEqual("significant".distanceMostFreqK(between: "capabilities", K: 2), 7)
+    }
+
     static let allTests = [
         ("testDistanceLevenshtein", testDistanceLevenshtein),
         ("testDistanceDamerauLevenshtein", testDistanceDamerauLevenshtein),

--- a/Tests/StringMetricTests/StringMetricTests.swift
+++ b/Tests/StringMetricTests/StringMetricTests.swift
@@ -31,7 +31,12 @@ class StringMetricTests: XCTestCase {
     }
 
     func testDistanceMostFreqK() {
-        XCTAssertEqual("research".distanceMostFreqK(between: "seeking", K: 2), 6)
+        XCTAssertEqual("research".distanceMostFreqK(between: "seeking", K: 2), 8)
+        XCTAssertEqual("night".distanceMostFreqK(between: "nacht", K: 2), 9)
+        XCTAssertEqual("my".distanceMostFreqK(between: "a", K: 2), 10)
+        XCTAssertEqual("research".distanceMostFreqK(between: "resarch", K: 2), 6)
+        XCTAssertEqual("aaaaabbbb".distanceMostFreqK(between: "ababababa", K: 2), 1)
+        XCTAssertEqual("significant".distanceMostFreqK(between: "capabilities", K: 2), 7)
     }
 
     func testDistanceJaroWinkler() {
@@ -44,14 +49,6 @@ class StringMetricTests: XCTestCase {
         XCTAssertEqual("DIXON".distanceJaroWinkler(between: "DICKSONX"), 0.814, accuracy: 0.001)
         XCTAssertEqual("kitten".distanceJaroWinkler(between: "sitting"), 0.746, accuracy: 0.001)
         XCTAssertEqual("君子和而不同".distanceJaroWinkler(between: "小人同而不和"), 0.555, accuracy: 0.001)
-    }
-
-    func testDistanceMostFrequentK() {
-        XCTAssertEqual("night".distanceMostFreqK(between: "nacht", K: 2), 9)
-        XCTAssertEqual("my".distanceMostFreqK(between: "a", K: 2), 10)
-        XCTAssertEqual("research".distanceMostFreqK(between: "resarch", K: 2), 6)
-        XCTAssertEqual("aaaaabbbb".distanceMostFreqK(between: "ababababa", K: 2), 1)
-        XCTAssertEqual("significant".distanceMostFreqK(between: "capabilities", K: 2), 7)
     }
 
     static let allTests = [


### PR DESCRIPTION
This pull request:

- Resolves errors in the `distanceMostFreqK(between:)` method, and adds additional test cases.
- Refactors the `distanceJaroWinkler(between:)` method to avoid a separate for loop for calculating the number of transpositions.
  - Renames various internal variable names for clarity.
  - Uses `Foundation`s `commonPrefix(with:)` method.
  - I did some local performance analysis on my machine and found that for the modified unit test below the new implementation **reduced the average test run time to 1.28s (whereas current `master` averaged 4.81s), a saving of over 73%.** The `measureMetrics(…)` method calculates the average over 10 runs. N.B. I removed the `XCTAssertEqual` statements for the purposes of benchmarking in order to isolate the performance of the actual method call itself (but I didn't commit this change).
```
func testDistanceJaroWinkler() {
        self.measureMetrics([XCTPerformanceMetric.wallClockTime], automaticallyStartMeasuring: true) {
            for i in 0..<20000 {
                "".distanceJaroWinkler(between: "")
                "".distanceJaroWinkler(between: "Yo")
                "search".distanceJaroWinkler(between: "find")
                "search".distanceJaroWinkler(between: "search")
                "MARTHA".distanceJaroWinkler(between: "MARHTA")
                "DWAYNE".distanceJaroWinkler(between: "DUANE")
                "DIXON".distanceJaroWinkler(between: "DICKSONX")
                "kitten".distanceJaroWinkler(between: "sitting")
                "君子和而不同".distanceJaroWinkler(between: "小人同而不和")
            }
        }
}
```
- Refactors the `distanceHamming(between:)` method for performance. Uses a similar benchmarking method as show above, this **reduced the average test run time to 0.285s (whereas current `master` averaged 0.333s), a saving of over 14%.**
- Uses `String` fast enumeration (rather than subscripting by index, which is very slow) where possible in all string metric methods.
- Avoids repeated calls to `self.count` and `target.count` in all string metric methods (e.g. this should offer small savings to execution time if the methods are called repeatedly in tight loops).
- Corrects some typos in unit test names.